### PR TITLE
Ignore regions fix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,4 +37,4 @@ jobs:
           key: v1/${{ runner.os }}/ruby-${{ matrix.ruby }}/${{ hashFiles('**/Gemfile.lock') }}
           restore-keys: v1/${{ runner.os }}/ruby-${{ matrix.ruby }}/
       - run: bundle install
-      - run: for file in specs/*.rb; do ruby $file; done
+      - run: for file in specs/*.rb; do echo $file; bundle exec ruby $file; done

--- a/percy/providers/generic_provider.rb
+++ b/percy/providers/generic_provider.rb
@@ -106,8 +106,8 @@ module Percy
 
     def get_region_object(selector, element)
       scale_factor = metadata.scale_factor
-      location = hashed(element.location)
-      size = hashed(element.size)
+      location = { 'x' => element.location.x, 'y' => element.location.y }
+      size = { 'height' => element.size.height, 'width' => element.size.width }
       coordinates = {
         'top' => location['y'] * scale_factor,
         'bottom' => (location['y'] + size['height']) * scale_factor,

--- a/percy/providers/generic_provider.rb
+++ b/percy/providers/generic_provider.rb
@@ -133,7 +133,9 @@ module Percy
 
     def get_regions_by_ids(elements_array, ids)
       ids.each do |id|
-        element = driver.find_element(Appium::Core::Base::SearchContext::FINDERS[:accessibility_id], id)
+        # Appium::Core::Base::SearchContext::FINDERS[:xpath] returns `accessibility id`
+        # instead of `:accessibility_id`, causes error
+        element = driver.find_element(:accessibility_id, id)
         selector = "id: #{id}"
         region = get_region_object(selector, element)
         elements_array << region

--- a/specs/generic_providers.rb
+++ b/specs/generic_providers.rb
@@ -12,8 +12,6 @@ require_relative 'mocks/mock_methods'
 class TestGenericProvider < Minitest::Test
   include Appium
   COMPARISON_RESPONSE = { 'comparison' => { 'id' => 123, 'url' => 'https://percy-build-url' } }.freeze
-  LocationStruct = Struct.new(:x, :y)
-  SizeStruct = Struct.new(:width, :height)
 
   def setup
     @existing_dir = 'existing-dir'
@@ -236,8 +234,8 @@ class TestGenericProvider < Minitest::Test
   def test_get_region_object
     mock_element = Minitest::Mock.new
     2.times do
-      mock_element.expect(:location, LocationStruct.new(10, 20))
-      mock_element.expect(:size, SizeStruct.new(100, 200))
+      mock_element.expect(:location, Selenium::WebDriver::Point.new(10, 20))
+      mock_element.expect(:size, Selenium::WebDriver::Dimension.new(100, 200))
     end
 
     result = @generic_provider.get_region_object('my-selector', mock_element)
@@ -253,8 +251,8 @@ class TestGenericProvider < Minitest::Test
   def test_get_regions_by_xpath
     mock_element = Minitest::Mock.new
     2.times do
-      mock_element.expect(:location, LocationStruct.new(10, 20))
-      mock_element.expect(:size, SizeStruct.new(100, 200))
+      mock_element.expect(:location, Selenium::WebDriver::Point.new(10, 20))
+      mock_element.expect(:size, Selenium::WebDriver::Dimension.new(100, 200))
     end
 
     @mock_webdriver.expect(:find_element, mock_element,
@@ -286,8 +284,8 @@ class TestGenericProvider < Minitest::Test
   def test_get_regions_by_ids
     mock_element = Minitest::Mock.new
     2.times do
-      mock_element.expect(:location, LocationStruct.new(10, 20))
-      mock_element.expect(:size, SizeStruct.new(100, 200))
+      mock_element.expect(:location, Selenium::WebDriver::Point.new(10, 20))
+      mock_element.expect(:size, Selenium::WebDriver::Dimension.new(100, 200))
     end
 
     @mock_webdriver.expect(:find_element, mock_element, [:accessibility_id, 'some_id'])
@@ -307,8 +305,8 @@ class TestGenericProvider < Minitest::Test
   def test_get_regions_by_ids_with_non_existing_element
     mock_element = Minitest::Mock.new
     2.times do
-      mock_element.expect(:location, LocationStruct.new(10, 20))
-      mock_element.expect(:size, SizeStruct.new(100, 200))
+      mock_element.expect(:location, Selenium::WebDriver::Point.new(10, 20))
+      mock_element.expect(:size, Selenium::WebDriver::Dimension.new(100, 200))
     end
 
     @mock_webdriver.expect(:find_element, [Appium::Core::Base::SearchContext::FINDERS[:accessibility_id], 'id1']) do
@@ -325,8 +323,8 @@ class TestGenericProvider < Minitest::Test
   def test_get_regions_by_elements
     mock_element = Minitest::Mock.new
     2.times do
-      mock_element.expect(:location, LocationStruct.new(10, 20))
-      mock_element.expect(:size, SizeStruct.new(100, 200))
+      mock_element.expect(:location, Selenium::WebDriver::Point.new(10, 20))
+      mock_element.expect(:size, Selenium::WebDriver::Dimension.new(100, 200))
     end
     mock_element.expect(:attribute, 'textView', ['class'])
 

--- a/specs/generic_providers.rb
+++ b/specs/generic_providers.rb
@@ -12,6 +12,8 @@ require_relative 'mocks/mock_methods'
 class TestGenericProvider < Minitest::Test
   include Appium
   COMPARISON_RESPONSE = { 'comparison' => { 'id' => 123, 'url' => 'https://percy-build-url' } }.freeze
+  LocationStruct = Struct.new(:x, :y)
+  SizeStruct = Struct.new(:width, :height)
 
   def setup
     @existing_dir = 'existing-dir'
@@ -233,8 +235,10 @@ class TestGenericProvider < Minitest::Test
 
   def test_get_region_object
     mock_element = Minitest::Mock.new
-    mock_element.expect(:location, { 'x' => 10, 'y' => 20 })
-    mock_element.expect(:size, { 'width' => 100, 'height' => 200 })
+    2.times do
+      mock_element.expect(:location, LocationStruct.new(10, 20))
+      mock_element.expect(:size, SizeStruct.new(100, 200))
+    end
 
     result = @generic_provider.get_region_object('my-selector', mock_element)
     expected_result = {
@@ -248,8 +252,10 @@ class TestGenericProvider < Minitest::Test
 
   def test_get_regions_by_xpath
     mock_element = Minitest::Mock.new
-    mock_element.expect(:location, { 'x' => 10, 'y' => 20 })
-    mock_element.expect(:size, { 'width' => 100, 'height' => 200 })
+    2.times do
+      mock_element.expect(:location, LocationStruct.new(10, 20))
+      mock_element.expect(:size, SizeStruct.new(100, 200))
+    end
 
     @mock_webdriver.expect(:find_element, mock_element,
                            [Appium::Core::Base::SearchContext::FINDERS[:xpath], '//path/to/element'])
@@ -279,8 +285,10 @@ class TestGenericProvider < Minitest::Test
 
   def test_get_regions_by_ids
     mock_element = Minitest::Mock.new
-    mock_element.expect(:location, { 'x' => 10, 'y' => 20 })
-    mock_element.expect(:size, { 'width' => 100, 'height' => 200 })
+    2.times do
+      mock_element.expect(:location, LocationStruct.new(10, 20))
+      mock_element.expect(:size, SizeStruct.new(100, 200))
+    end
 
     @mock_webdriver.expect(:find_element, mock_element,
                            [Appium::Core::Base::SearchContext::FINDERS[:accessibility_id], 'some_id'])
@@ -299,8 +307,10 @@ class TestGenericProvider < Minitest::Test
 
   def test_get_regions_by_ids_with_non_existing_element
     mock_element = Minitest::Mock.new
-    mock_element.expect(:location, { 'x' => 10, 'y' => 20 })
-    mock_element.expect(:size, { 'width' => 100, 'height' => 200 })
+    2.times do
+      mock_element.expect(:location, LocationStruct.new(10, 20))
+      mock_element.expect(:size, SizeStruct.new(100, 200))
+    end
 
     @mock_webdriver.expect(:find_element, [Appium::Core::Base::SearchContext::FINDERS[:accessibility_id], 'id1']) do
       raise Appium::Core::Error::NoSuchElementError, 'Test error'
@@ -315,8 +325,10 @@ class TestGenericProvider < Minitest::Test
 
   def test_get_regions_by_elements
     mock_element = Minitest::Mock.new
-    mock_element.expect(:location, { 'x' => 10, 'y' => 20 })
-    mock_element.expect(:size, { 'width' => 100, 'height' => 200 })
+    2.times do
+      mock_element.expect(:location, LocationStruct.new(10, 20))
+      mock_element.expect(:size, SizeStruct.new(100, 200))
+    end
     mock_element.expect(:attribute, 'textView', ['class'])
 
     elements_array = []

--- a/specs/generic_providers.rb
+++ b/specs/generic_providers.rb
@@ -290,8 +290,7 @@ class TestGenericProvider < Minitest::Test
       mock_element.expect(:size, SizeStruct.new(100, 200))
     end
 
-    @mock_webdriver.expect(:find_element, mock_element,
-                           [Appium::Core::Base::SearchContext::FINDERS[:accessibility_id], 'some_id'])
+    @mock_webdriver.expect(:find_element, mock_element, [:accessibility_id, 'some_id'])
 
     elements_array = []
     ids = ['some_id']

--- a/specs/screenshot.rb
+++ b/specs/screenshot.rb
@@ -19,6 +19,9 @@ class MockServerRequestHandler < WEBrick::HTTPServlet::AbstractServlet
   end
 end
 
+LocationStruct = Struct.new(:x, :y)
+SizeStruct = Struct.new(:width, :height)
+
 mock_server = WEBrick::HTTPServer.new(Port: 8000)
 mock_server.mount('/', MockServerRequestHandler)
 mock_server_thread = Thread.new { mock_server.start }
@@ -339,8 +342,10 @@ class TestPercyScreenshot < Minitest::Test
     mock_screenshot
 
     mock_element = Minitest::Mock.new
-    mock_element.expect(:location, { 'x' => 10, 'y' => 20 })
-    mock_element.expect(:size, { 'width' => 200, 'height' => 400 })
+    2.times do
+      mock_element.expect(:location, LocationStruct.new(10, 20))
+      mock_element.expect(:size, SizeStruct.new(200, 400))
+    end
 
     xpaths = ['//path/to/element']
 

--- a/specs/screenshot.rb
+++ b/specs/screenshot.rb
@@ -19,9 +19,6 @@ class MockServerRequestHandler < WEBrick::HTTPServlet::AbstractServlet
   end
 end
 
-LocationStruct = Struct.new(:x, :y)
-SizeStruct = Struct.new(:width, :height)
-
 mock_server = WEBrick::HTTPServer.new(Port: 8000)
 mock_server.mount('/', MockServerRequestHandler)
 mock_server_thread = Thread.new { mock_server.start }
@@ -343,8 +340,8 @@ class TestPercyScreenshot < Minitest::Test
 
     mock_element = Minitest::Mock.new
     2.times do
-      mock_element.expect(:location, LocationStruct.new(10, 20))
-      mock_element.expect(:size, SizeStruct.new(200, 400))
+      mock_element.expect(:location, Selenium::WebDriver::Point.new(10, 20))
+      mock_element.expect(:size, Selenium::WebDriver::Dimension.new(200, 400))
     end
 
     xpaths = ['//path/to/element']


### PR DESCRIPTION
when using ignore_regions by xpath/id/elements, we were getting error as:
```
[percy:ruby] Could not take screenshot "screenshot 2"
[percy:ruby] undefined method `as_json' for #<struct Selenium::WebDriver::Point x=189, y=144>
```

ignore_region by pixle-values was working correctly.

This pr resolves the issue as it was previously assumed that the `location` & `size` will be hash instead of structs.