### PR TITLE
added check for deviceScreenSize

### DIFF
--- a/percy/metadata/android_metadata.rb
+++ b/percy/metadata/android_metadata.rb
@@ -15,8 +15,13 @@ module Percy
     def device_screen_size
       caps = capabilities
       caps = caps.as_json unless caps.is_a?(Hash)
-      width, height = caps['deviceScreenSize'].split('x')
-      { 'width' => width.to_i, 'height' => height.to_i }
+      if caps['deviceScreenSize'].nil?
+        size = driver.window_size
+        { width: size.width.to_i, height: size.height.to_i }
+      else
+        width, height = caps['deviceScreenSize'].split('x')
+        { width: width.to_i, height: height.to_i }
+      end
     end
 
     def get_system_bars

--- a/specs/android_metadata.rb
+++ b/specs/android_metadata.rb
@@ -29,7 +29,27 @@ class TestAndroidMetadata < Minitest::Test
     @mock_webdriver.expect(:capabilities, android_capabilities.merge('viewportRect' => viewport))
 
     assert(viewport, @android_metadata.viewport)
+    @mock_webdriver.verify
+  end
 
+  def test_device_screen_size_when_device_screen_size_is_nil
+    # Mock capabilities to return a hash without 'deviceScreenSize'
+    android_capabilities = get_android_capabilities
+    android_capabilities.delete('deviceScreenSize')
+    @mock_webdriver.expect(:capabilities, android_capabilities)
+
+    # Mock driver.window_size to return a double with width and height
+    mock_window_size = Minitest::Mock.new
+    mock_window_size.expect(:width, 1080)
+    mock_window_size.expect(:height, 1920)
+    @mock_webdriver.expect(:window_size, mock_window_size)
+
+    # Call the method and assert the result
+    result = @android_metadata.device_screen_size
+    assert_equal({ width: 1080, height: 1920 }, result)
+
+    # Verify mocks
+    mock_window_size.verify
     @mock_webdriver.verify
   end
 


### PR DESCRIPTION
The enhancement improves the way device screen size is determined.
Previously, screen size always depended on the deviceScreenSize capability. Now, if deviceScreenSize is missing (nil), we automatically fallback to using the actual driver.window_size.

✅ Added a check for deviceScreenSize.

✅ If not present, fetches screen dimensions dynamically from the driver.

✅ Ensures more robust and flexible behavior across different device setups.

```
if caps['deviceScreenSize'].nil?
        size = driver.window_size
        { width: size.width.to_i, height: size.height.to_i }
 else
        width, height = caps['deviceScreenSize'].split('x')
        { width: width.to_i, height: height.to_i }
end
```