### PR TITLE
Fixed platform issue

### DIFF
--- a/percy/metadata/metadata_resolver.rb
+++ b/percy/metadata/metadata_resolver.rb
@@ -9,7 +9,8 @@ module Percy
     def self.resolve(driver)
       capabilities = driver.capabilities
       capabilities = capabilities.as_json unless capabilities.is_a?(Hash)
-      platform_name = (capabilities.fetch('platformName', nil) || capabilities.fetch('platform_name', '')).downcase
+      key = capabilities.keys.find { |k| k.downcase.gsub('_', '') == 'platformname' }
+      platform_name = capabilities[key]&.downcase
       case platform_name
       when 'android'
         Percy::AndroidMetadata.new(driver)

--- a/percy/metadata/metadata_resolver.rb
+++ b/percy/metadata/metadata_resolver.rb
@@ -9,7 +9,7 @@ module Percy
     def self.resolve(driver)
       capabilities = driver.capabilities
       capabilities = capabilities.as_json unless capabilities.is_a?(Hash)
-      platform_name = capabilities.fetch('platformName', '').downcase
+      platform_name = (capabilities.fetch('platformName', nil) || capabilities.fetch('platform_name', '')).downcase
       case platform_name
       when 'android'
         Percy::AndroidMetadata.new(driver)

--- a/specs/metadata_resolver.rb
+++ b/specs/metadata_resolver.rb
@@ -21,6 +21,15 @@ class MetadataResolverTestCase < Minitest::Test
     @mock_webdriver.verify
   end
 
+  def test_android_resolved_with_platform_name
+    @mock_webdriver.expect(:capabilities, { 'platform_name' => 'Android' })
+    @mock_webdriver.expect(:capabilities, { 'platform_name' => 'Android' })
+    resolved_metadata = Percy::MetadataResolver.resolve(@mock_webdriver)
+
+    assert_instance_of(Percy::AndroidMetadata, resolved_metadata)
+    @mock_webdriver.verify
+  end
+
   def test_ios_resolved
     @mock_webdriver.expect(:capabilities, { 'platformName' => 'iOS' })
     resolved_metadata = Percy::MetadataResolver.resolve(@mock_webdriver)
@@ -29,10 +38,37 @@ class MetadataResolverTestCase < Minitest::Test
     @mock_webdriver.verify
   end
 
+  def test_ios_resolved_with_platform_name
+    @mock_webdriver.expect(:capabilities, { 'platform_name' => 'iOS' })
+    resolved_metadata = Percy::MetadataResolver.resolve(@mock_webdriver)
+
+    assert_instance_of(Percy::IOSMetadata, resolved_metadata)
+    @mock_webdriver.verify
+  end
+
+  def test_platformName_precedence_over_platform_name
+    @mock_webdriver.expect(:capabilities, { 'platformName' => 'Android', 'platform_name' => 'iOS' })
+    @mock_webdriver.expect(:capabilities, { 'platformName' => 'Android', 'platform_name' => 'iOS' })
+    resolved_metadata = Percy::MetadataResolver.resolve(@mock_webdriver)
+
+    assert_instance_of(Percy::AndroidMetadata, resolved_metadata)
+    @mock_webdriver.verify
+  end
+
   def test_unknown_platform_exception
     @mock_webdriver.expect(:capabilities, { 'platformName' => 'Something Random' })
 
     assert_raises(Exception) do
+      Percy::MetadataResolver.resolve(@mock_webdriver)
+    end
+
+    @mock_webdriver.verify
+  end
+
+  def test_unknown_platform_exception_with_platform_name
+    @mock_webdriver.expect(:capabilities, { 'platform_name' => 'Something Random' })
+
+    assert_raises(PlatformNotSupported) do
       Percy::MetadataResolver.resolve(@mock_webdriver)
     end
 

--- a/specs/metadata_resolver.rb
+++ b/specs/metadata_resolver.rb
@@ -20,6 +20,15 @@ class MetadataResolverTestCase < Minitest::Test
     assert_instance_of(Percy::AndroidMetadata, resolved_metadata)
     @mock_webdriver.verify
   end
+  
+  def test_android_resolved_with_PLATFORM_NAME
+    @mock_webdriver.expect(:capabilities, { 'PLATFORM_NAME' => 'Android' })
+    @mock_webdriver.expect(:capabilities, { 'PLATFORM_NAME' => 'Android' })
+    resolved_metadata = Percy::MetadataResolver.resolve(@mock_webdriver)
+
+    assert_instance_of(Percy::AndroidMetadata, resolved_metadata)
+    @mock_webdriver.verify
+  end
 
   def test_android_resolved_with_platform_name
     @mock_webdriver.expect(:capabilities, { 'platform_name' => 'Android' })


### PR DESCRIPTION
1. Browserstack passes plateformName as platform_name that causes error PlatformNotSupported. 
2. Have added support for both platformName and platform_name. 
![Screenshot 2025-06-02 at 6 09 23 PM](https://github.com/user-attachments/assets/1ec2571e-8099-4fb3-8a22-6c33bc5a12f7)
3. This will cover:
    a.  platformName
    b. platform_name
    c. PlatformName
    d. PLATFORM_NAME
    e. etc