### PR TITLE
fix: support appium_lib_core 12.x (FINDERS removal) + fix Android screen size (PER-7786)

### DIFF
--- a/percy/metadata/android_metadata.rb
+++ b/percy/metadata/android_metadata.rb
@@ -15,12 +15,15 @@ module Percy
     def device_screen_size
       caps = capabilities
       caps = caps.as_json unless caps.is_a?(Hash)
+      # Use string keys to match the IosMetadata implementation and every
+      # consumer (generic_provider, app_automate, _get_tag), all of which read
+      # device_screen_size['width'] / ['height'].
       if caps['deviceScreenSize'].nil?
         size = driver.window_size
-        { width: size.width.to_i, height: size.height.to_i }
+        { 'width' => size.width.to_i, 'height' => size.height.to_i }
       else
         width, height = caps['deviceScreenSize'].split('x')
-        { width: width.to_i, height: height.to_i }
+        { 'width' => width.to_i, 'height' => height.to_i }
       end
     end
 

--- a/percy/providers/generic_provider.rb
+++ b/percy/providers/generic_provider.rb
@@ -137,7 +137,10 @@ module Percy
 
     def get_regions_by_xpath(elements_array, xpaths)
       xpaths.each do |xpath|
-        element = driver.find_element(Appium::Core::Base::SearchContext::FINDERS[:xpath], xpath)
+        # Pass the :xpath finder symbol directly. appium_lib_core 12.x removed
+        # Appium::Core::Base::SearchContext::FINDERS; the symbol form works
+        # across all supported appium_lib versions.
+        element = driver.find_element(:xpath, xpath)
         selector = "xpath: #{xpath}"
         if element
           region = get_region_object(selector, element)

--- a/specs/android_metadata.rb
+++ b/specs/android_metadata.rb
@@ -46,7 +46,7 @@ class TestAndroidMetadata < Minitest::Test
 
     # Call the method and assert the result
     result = @android_metadata.device_screen_size
-    assert_equal({ width: 1080, height: 1920 }, result)
+    assert_equal({ 'width' => 1080, 'height' => 1920 }, result)
 
     # Verify mocks
     mock_window_size.verify

--- a/specs/android_metadata.rb
+++ b/specs/android_metadata.rb
@@ -53,6 +53,14 @@ class TestAndroidMetadata < Minitest::Test
     @mock_webdriver.verify
   end
 
+  def test_device_screen_size_when_device_screen_size_is_present
+    # 'deviceScreenSize' => '1080x2280' from get_android_capabilities; parsed into string-keyed hash
+    @mock_webdriver.expect(:capabilities, get_android_capabilities)
+    result = @android_metadata.device_screen_size
+    assert_equal({ 'width' => 1080, 'height' => 2280 }, result)
+    @mock_webdriver.verify
+  end
+
   def test_get_system_bars
     system_bars = {
       'statusBar' => { 'height' => 83 },

--- a/specs/app_automate.rb
+++ b/specs/app_automate.rb
@@ -67,9 +67,12 @@ class TestAppAutomate < Minitest::Test
   end
 
   def test_execute_percy_screenshot_end
-    @app_automate.stub(:execute_percy_screenshot_begin, 'deviceName' => 'abc', 'osVersion' => '123') do
+    # Wrap the stub return hashes in explicit braces. Under Ruby 3 keyword
+    # argument separation, a bare trailing hash is otherwise parsed as keyword
+    # args to Minitest's stub, raising ArgumentError.
+    @app_automate.stub(:execute_percy_screenshot_begin, { 'deviceName' => 'abc', 'osVersion' => '123' }) do
       @app_automate.stub(:execute_percy_screenshot_end, nil) do
-        @app_automate.stub(:screenshot, 'link' => 'https://link') do
+        @app_automate.stub(:screenshot, { 'link' => 'https://link' }) do
           @app_automate.screenshot('name')
         end
       end

--- a/specs/generic_providers.rb
+++ b/specs/generic_providers.rb
@@ -256,7 +256,7 @@ class TestGenericProvider < Minitest::Test
     end
 
     @mock_webdriver.expect(:find_element, mock_element,
-                           [Appium::Core::Base::SearchContext::FINDERS[:xpath], '//path/to/element'])
+                           [:xpath, '//path/to/element'])
 
     elements_array = []
     xpaths = ['//path/to/element']
@@ -271,7 +271,7 @@ class TestGenericProvider < Minitest::Test
   end
 
   def test_get_regions_by_xpath_with_non_existing_element
-    @mock_webdriver.expect(:find_element, [Appium::Core::Base::SearchContext::FINDERS[:xpath], '//path/to/element']) do
+    @mock_webdriver.expect(:find_element, [:xpath, '//path/to/element']) do
       raise Appium::Core::Error::NoSuchElementError, 'Test error'
     end
     elements_array = []
@@ -309,7 +309,7 @@ class TestGenericProvider < Minitest::Test
       mock_element.expect(:size, Selenium::WebDriver::Dimension.new(100, 200))
     end
 
-    @mock_webdriver.expect(:find_element, [Appium::Core::Base::SearchContext::FINDERS[:accessibility_id], 'id1']) do
+    @mock_webdriver.expect(:find_element, [:accessibility_id, 'id1']) do
       raise Appium::Core::Error::NoSuchElementError, 'Test error'
     end
 

--- a/specs/screenshot.rb
+++ b/specs/screenshot.rb
@@ -383,7 +383,7 @@ class TestPercyScreenshot < Minitest::Test
                     })
     end
     driver.expect(:find_element, mock_element,
-                  [Appium::Core::Base::SearchContext::FINDERS[:xpath], '//path/to/element'])
+                  [:xpath, '//path/to/element'])
 
     percy_screenshot(driver, 'screenshot 1', ignore_regions_xpaths: xpaths)
 


### PR DESCRIPTION
## What
Two issues against **appium_lib 16 / appium_lib_core 12.x / selenium-webdriver 4.x**:

1. `generic_provider` used `Appium::Core::Base::SearchContext::FINDERS[:xpath]` — a constant **removed in appium_lib_core 12.x** (`NameError`).
2. `AndroidMetadata#device_screen_size` returned **symbol-keyed** hashes while every consumer (`generic_provider`, `app_automate`, `_get_tag`) reads **string keys** — so Android screen size always silently fell back to `1`/`nil`.

## Fix
- Pass the `:xpath` finder symbol directly (matches existing `:accessibility_id` usage; works on all appium_lib versions).
- Return string keys from Android `device_screen_size`, matching `IosMetadata` and all callers.
- Specs updated for symbol finders, string keys, and Ruby 3 keyword-arg separation in Minitest `stub`.

## Validation
- Full spec suite green on appium_lib **16.2** / core **12.2** / selenium **4.32** (Ruby 3.1.2).
- End-to-end on BrowserStack App Automate: appium_lib **11 / 12 / 14 / 15 / 16** × Appium servers **1.22.0** and **2.15.0** → **7/7 passed** (valid pairings; newer appium_lib `hide_keyboard` is unsupported by Appium 1.x servers — a client/server constraint, not Percy).

Part of PER-7786.

🤖 Generated with [Claude Code](https://claude.com/claude-code)