### PR TITLE
releasing v0.0.9-beta.2

### DIFF
--- a/percy/version.rb
+++ b/percy/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Percy
-  VERSION = '0.0.9.beta1'.freeze
+  VERSION = '0.0.9.beta2'.freeze
 end


### PR DESCRIPTION
Version bump to **0.0.9.beta2** for the Appium version-compatibility work (PER-7786, #33 — appium_lib_core 12.x FINDERS + Android screen size).

- `percy/version.rb`: 0.0.9.beta1 → 0.0.9.beta2

🤖 Generated with [Claude Code](https://claude.com/claude-code)