### PR TITLE
releasing v0.0.9

### DIFF
--- a/percy/version.rb
+++ b/percy/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Percy
-  VERSION = '0.0.9.beta.2'.freeze
+  VERSION = '0.0.9'.freeze
 end


### PR DESCRIPTION
Stable release **0.0.9** (PER-7786). Promotes 0.0.9.beta.2 after beta validation.

- `percy/version.rb`: 0.0.9.beta.2 → 0.0.9

(Branch `release-0.0.9-stable` — `release-v0.0.9` is taken by stale PR #25.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)