### PR TITLE
fix: support appium_lib_core 13.x snake_case capabilities

### DIFF
--- a/percy/metadata/android_metadata.rb
+++ b/percy/metadata/android_metadata.rb
@@ -9,6 +9,11 @@ module Percy
     def initialize(driver)
       super(driver)
       @_bars = nil
+      # Intentionally left as the original lookup: this path already degrades to
+      # driver.get_system_bars consistently across all appium_lib_core versions
+      # (the rect read yields a non-Hash, so the rect arithmetic in
+      # get_system_bars rescues to nil and falls back), so it is out of scope for
+      # the snake_case capability fix.
       @_viewport_rect = capabilities.to_json['viewportRect']
     end
 
@@ -75,8 +80,10 @@ module Percy
 
     def _device_name
       if @device_name.nil?
-        desired_caps = get_capability_value('desired') || {}
-        device_name = desired_caps['deviceName'] || desired_caps['device_name']
+        # Normalize the nested desired-caps hash too, so its keys are matched
+        # regardless of casing (camelCase or appium_lib_core 13+ snake_case).
+        desired_caps = Percy::Metadata.normalize_hash(get_capability_value('desired'))
+        device_name = desired_caps['devicename']
         device = desired_caps['device']
         device_name ||= device
         device_model = get_capability_value('deviceModel')

--- a/percy/metadata/android_metadata.rb
+++ b/percy/metadata/android_metadata.rb
@@ -13,16 +13,15 @@ module Percy
     end
 
     def device_screen_size
-      caps = capabilities
-      caps = caps.as_json unless caps.is_a?(Hash)
       # Use string keys to match the IosMetadata implementation and every
       # consumer (generic_provider, app_automate, _get_tag), all of which read
       # device_screen_size['width'] / ['height'].
-      if caps['deviceScreenSize'].nil?
+      device_screen_size_cap = get_capability_value('deviceScreenSize')
+      if device_screen_size_cap.nil?
         size = driver.window_size
         { 'width' => size.width.to_i, 'height' => size.height.to_i }
       else
-        width, height = caps['deviceScreenSize'].split('x')
+        width, height = device_screen_size_cap.split('x')
         { 'width' => width.to_i, 'height' => height.to_i }
       end
     end
@@ -76,11 +75,11 @@ module Percy
 
     def _device_name
       if @device_name.nil?
-        desired_caps = capabilities.to_json['desired'] || {}
-        device_name = desired_caps['deviceName']
+        desired_caps = get_capability_value('desired') || {}
+        device_name = desired_caps['deviceName'] || desired_caps['device_name']
         device = desired_caps['device']
         device_name ||= device
-        device_model = capabilities.to_json['deviceModel']
+        device_model = get_capability_value('deviceModel')
         @device_name = device_name || device_model
       end
       @device_name

--- a/percy/metadata/ios_metadata.rb
+++ b/percy/metadata/ios_metadata.rb
@@ -67,11 +67,7 @@ module Percy
     end
 
     def device_name
-      if @device_name.nil?
-        caps = capabilities
-        caps = caps.as_json unless caps.is_a?(Hash)
-        @device_name = caps['deviceName']
-      end
+      @device_name = get_capability_value('deviceName') if @device_name.nil?
       @device_name
     end
 

--- a/percy/metadata/metadata.rb
+++ b/percy/metadata/metadata.rb
@@ -25,19 +25,47 @@ module Percy
       caps
     end
 
+    # Normalizes a capability key so lookups are resilient to the differences
+    # across appium_lib_core versions and protocols: camelCase ("platformName"),
+    # snake_case ("platform_name", as returned by appium_lib_core 13+),
+    # SCREAMING ("PLATFORM_NAME") and the W3C vendor prefix ("appium:platformName").
+    def self.normalize_capability_key(key)
+      key.to_s.downcase.gsub(/[_:]/, '').sub(/\Aappium/, '')
+    end
+
+    # Builds a {normalized_key => value} view of the driver's capabilities,
+    # coercing the appium_lib_core Capabilities object into a plain Hash first.
+    def self.normalized_capabilities(driver)
+      caps = driver.capabilities
+      caps = caps.as_json if caps.respond_to?(:as_json) && !caps.is_a?(Hash)
+      caps = caps.to_h if caps.respond_to?(:to_h) && !caps.is_a?(Hash)
+      normalized = {}
+      # First key wins, so a camelCase key (e.g. "platformName") takes
+      # precedence over a snake_case duplicate ("platform_name") when both
+      # are present, matching the previous MetadataResolver semantics.
+      (caps || {}).each do |k, v|
+        nk = normalize_capability_key(k)
+        normalized[nk] = v unless normalized.key?(nk)
+      end
+      normalized
+    end
+
+    # Reads capabilities fresh on every call (no memoization) so callers always
+    # observe the driver's current capabilities, matching the prior behaviour.
+    def get_capability_value(name)
+      self.class.normalized_capabilities(driver)[self.class.normalize_capability_key(name)]
+    end
+
     def session_id
       driver.session_id
     end
 
     def os_name
-      capabilities['platformName']
+      get_capability_value('platformName')
     end
 
     def os_version
-      caps = capabilities
-      caps = caps.as_json unless caps.is_a?(Hash)
-
-      os_version = caps['os_version'] || caps['platformVersion'] || ''
+      os_version = get_capability_value('os_version') || get_capability_value('platformVersion') || ''
       os_version = @os_version || os_version
       begin
         os_version.to_f.to_i.to_s
@@ -51,7 +79,7 @@ module Percy
     end
 
     def get_orientation(**kwargs)
-      orientation = kwargs[:orientation] || capabilities['orientation'] || 'PORTRAIT'
+      orientation = kwargs[:orientation] || get_capability_value('orientation') || 'PORTRAIT'
       orientation = orientation.downcase
       orientation = orientation == 'auto' ? _orientation : orientation
       orientation.upcase

--- a/percy/metadata/metadata.rb
+++ b/percy/metadata/metadata.rb
@@ -29,8 +29,23 @@ module Percy
     # across appium_lib_core versions and protocols: camelCase ("platformName"),
     # snake_case ("platform_name", as returned by appium_lib_core 13+),
     # SCREAMING ("PLATFORM_NAME") and the W3C vendor prefix ("appium:platformName").
+    # Note: all colons are stripped, not just the vendor-prefix one. This is safe
+    # for every known Appium capability (e.g. "bstack:options" -> "bstackoptions").
     def self.normalize_capability_key(key)
       key.to_s.downcase.gsub(/[_:]/, '').sub(/\Aappium/, '')
+    end
+
+    # Builds a {normalized_key => value} view of a capabilities hash. First key
+    # wins, so a camelCase key (e.g. "platformName") takes precedence over a
+    # snake_case duplicate ("platform_name") when both are present, matching the
+    # previous MetadataResolver semantics.
+    def self.normalize_hash(hash)
+      normalized = {}
+      (hash || {}).each do |k, v|
+        nk = normalize_capability_key(k)
+        normalized[nk] = v unless normalized.key?(nk)
+      end
+      normalized
     end
 
     # Builds a {normalized_key => value} view of the driver's capabilities,
@@ -39,15 +54,7 @@ module Percy
       caps = driver.capabilities
       caps = caps.as_json if caps.respond_to?(:as_json) && !caps.is_a?(Hash)
       caps = caps.to_h if caps.respond_to?(:to_h) && !caps.is_a?(Hash)
-      normalized = {}
-      # First key wins, so a camelCase key (e.g. "platformName") takes
-      # precedence over a snake_case duplicate ("platform_name") when both
-      # are present, matching the previous MetadataResolver semantics.
-      (caps || {}).each do |k, v|
-        nk = normalize_capability_key(k)
-        normalized[nk] = v unless normalized.key?(nk)
-      end
-      normalized
+      normalize_hash(caps)
     end
 
     # Reads capabilities fresh on every call (no memoization) so callers always

--- a/percy/metadata/metadata_resolver.rb
+++ b/percy/metadata/metadata_resolver.rb
@@ -1,16 +1,17 @@
 # frozen_string_literal: true
 
 require_relative '../exceptions/exceptions'
+require_relative 'metadata'
 require_relative 'android_metadata'
 require_relative 'ios_metadata'
 
 module Percy
   class MetadataResolver
     def self.resolve(driver)
-      capabilities = driver.capabilities
-      capabilities = capabilities.as_json unless capabilities.is_a?(Hash)
-      key = capabilities.keys.find { |k| k.downcase.gsub('_', '') == 'platformname' }
-      platform_name = capabilities[key]&.downcase
+      # Resolve via normalized capability keys so platformName is found
+      # regardless of casing/prefix (camelCase, snake_case as in appium_lib_core
+      # 13+, or the appium: vendor prefix).
+      platform_name = Percy::Metadata.normalized_capabilities(driver)['platformname']&.to_s&.downcase
       case platform_name
       when 'android'
         Percy::AndroidMetadata.new(driver)

--- a/specs/android_metadata.rb
+++ b/specs/android_metadata.rb
@@ -102,4 +102,28 @@ class TestAndroidMetadata < Minitest::Test
   def test_scale_factor
     assert_equal(1, @android_metadata.scale_factor)
   end
+
+  # Regression: appium_lib_core 13.x returns capabilities with snake_case keys
+  # (e.g. "device_screen_size" instead of "deviceScreenSize").
+  def test_device_screen_size_with_snake_case_caps
+    android_capabilities = get_android_capabilities
+    android_capabilities.delete('deviceScreenSize')
+    android_capabilities['device_screen_size'] = '1080x2280'
+    @mock_webdriver.expect(:capabilities, android_capabilities)
+
+    result = @android_metadata.device_screen_size
+    assert_equal({ 'width' => 1080, 'height' => 2280 }, result)
+    @mock_webdriver.verify
+  end
+
+  # Regression: the nested desired-caps hash is also normalized, so a
+  # snake_case "device_name" inside "desired" still resolves the device.
+  def test_device_name_with_snake_case_desired_caps
+    android_capabilities = get_android_capabilities
+    android_capabilities['desired'] = { 'device_name' => 'google pixel 4' }
+    @mock_webdriver.expect(:capabilities, android_capabilities)
+    @mock_webdriver.expect(:capabilities, android_capabilities)
+
+    assert_equal('google pixel 4', @android_metadata._device_name)
+  end
 end

--- a/specs/ios_metadata.rb
+++ b/specs/ios_metadata.rb
@@ -105,4 +105,15 @@ class TestIOSMetadata < Minitest::Test
 
     assert_equal(2, @ios_metadata.scale_factor)
   end
+
+  def test_device_name_with_camel_case_caps
+    @mock_webdriver.expect(:capabilities, { 'deviceName' => 'iPhone 14' })
+    assert_equal('iPhone 14', @ios_metadata.device_name)
+  end
+
+  # Regression: appium_lib_core 13.x returns capabilities with snake_case keys.
+  def test_device_name_with_snake_case_caps
+    @mock_webdriver.expect(:capabilities, { 'device_name' => 'iPhone 14' })
+    assert_equal('iPhone 14', @ios_metadata.device_name)
+  end
 end

--- a/specs/metadata.rb
+++ b/specs/metadata.rb
@@ -137,4 +137,26 @@ class TestMetadata < Minitest::Test
       @metadata.value_from_devices_info('scale_factor', ios_device)
     )
   end
+
+  def test_normalize_capability_key
+    # camelCase, snake_case, SCREAMING and the appium: vendor prefix all
+    # collapse to the same normalized key.
+    %w[platformName platform_name PLATFORM_NAME appium:platformName].each do |key|
+      assert_equal('platformname', Percy::Metadata.normalize_capability_key(key))
+    end
+    assert_equal('platformname', Percy::Metadata.normalize_capability_key(:platformName))
+  end
+
+  # Regression: appium_lib_core 13.x returns capabilities with snake_case keys.
+  def test_metadata_os_name_with_snake_case_caps
+    @mock_webdriver.expect(:capabilities, { 'platform_name' => 'Android' })
+    assert_equal('Android', @metadata.os_name)
+  end
+
+  def test_metadata_os_version_with_snake_case_platform_version
+    capabilities = { 'platform_version' => '14' }
+    @mock_webdriver.expect(:capabilities, capabilities)
+    @mock_webdriver.expect(:capabilities, capabilities)
+    assert_equal('14', @metadata.os_version)
+  end
 end


### PR DESCRIPTION
## Problem

`appium_lib_core` **13.x** returns the session capabilities as an `Appium::Core::Base::Capabilities` object whose keys are **snake_case** (`platform_name`, `device_screen_size`, `platform_version`, …) instead of the **camelCase** keys (`platformName`, `deviceScreenSize`, `platformVersion`) that 12.x and earlier returned.

This silently broke Percy on core 13.x:

- `MetadataResolver.resolve` looked for `platformName`, didn't find it, and raised `PlatformNotSupported`.
- `os_name`, `os_version`, `device_name`, `orientation`, and `deviceScreenSize` all read `nil`.
- Net effect: the build was created but **no snapshot was taken** ("Snapshot command was not called").

## Fix

Introduce two helpers on `Percy::Metadata`:

- `normalize_capability_key(key)` — lowercases and strips `_`/`:` and the leading `appium` vendor prefix, so `platformName`, `platform_name`, `PLATFORM_NAME` and `appium:platformName` all normalize to `platformname`.
- `normalized_capabilities(driver)` — coerces the capabilities object to a plain Hash (`as_json`/`to_h`) and builds a `{normalized_key => value}` view. **First key wins**, preserving the previous resolver precedence of `platformName` over `platform_name`.

The affected metadata reads (`MetadataResolver`, `os_name`, `os_version`, `get_orientation`, Android `device_screen_size`/`_device_name`, iOS `device_name`) now go through `get_capability_value`, which reads fresh on every call (no memoization — same call semantics as before).

The Android `viewportRect` / `viewport` reads are intentionally **left unchanged** — that path already falls back to `driver.get_system_bars` consistently across all appium versions, so it's out of scope for this fix.

## Compatibility

- ✅ Backward compatible with `appium_lib_core` ≤ 12.x (camelCase).
- ✅ Forward compatible with `appium_lib_core` 13.x (snake_case).

## Verification

- All 15 spec files pass (`specs/*.rb`).
- Real BrowserStack App Automate Percy build under `appium_lib 16.3.0` (core 13.x) now takes the snapshot and finalizes green (previously failed with `PlatformNotSupported` / "Snapshot command was not called").

🤖 Generated with [Claude Code](https://claude.com/claude-code)