### PR TITLE
Release v1.0.1

### DIFF
--- a/percy/version.rb
+++ b/percy/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Percy
-  VERSION = '0.0.9'.freeze
+  VERSION = '1.0.1'.freeze
 end


### PR DESCRIPTION
## What

Bump version `0.0.9` → **`1.0.1`**.

## Why

RubyGems resolves the **`latest`** of `percy-appium-app` by semver ordering, so it currently points at a **stray `1.0.0` published 2024-10-28** — which sorts above our real release line (`0.0.9`). That `1.0.0` is **broken with real Appium drivers**: its `MetadataResolver` does a strict `capabilities.fetch('platformName')`, but `driver.capabilities.as_json` yields snake_case keys, so it raises `PlatformNotSupported` and silently takes no snapshot (build finalizes empty).

Net effect today: `gem install percy-appium-app` (no version pin) installs the broken `1.0.0`.

Cutting **`1.0.1`** from current `main` makes `latest` resolve to working code again (`1.0.1 > 1.0.0 > 0.0.9`), without needing to yank `1.0.0`.

## What's included

`1.0.1` is cut from `main` after merging the appium_lib_core 13.x fix (#37), so this release:
- ✅ Resolves platform/metadata via casing- and prefix-insensitive capability lookup.
- ✅ Supports **appium_lib_core 13.x** (snake_case capabilities), in addition to ≤ 12.x — fixing the `PlatformNotSupported` / empty-build failure on the latest `appium_lib`.

## Verification

The code is identical to the merged #37 state, which was verified by:
- All 15 spec files passing (incl. new snake_case regression tests).
- Real BrowserStack App Automate Percy builds green under appium_lib 16.3.0 (core 13.x) and 16.2.0 (core 12.x).

🤖 Generated with [Claude Code](https://claude.com/claude-code)