### PR TITLE
ci: run tests against an unpublished @percy/cli branch (PER-9772)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,7 @@ on:
   workflow_dispatch:
     inputs:
       branch:
+        description: Which branch of @percy/cli to build from source for this run
         required: false
         type: string
         default: master
@@ -42,6 +43,24 @@ jobs:
           key: v1/${{ runner.os }}/ruby-${{ matrix.ruby }}/${{ hashFiles('**/Gemfile.lock') }}
           restore-keys: v1/${{ runner.os }}/ruby-${{ matrix.ruby }}/
       - run: bundle install
+      - name: Set up @percy/cli from git
+        if: ${{ github.event_name == 'workflow_dispatch' }}
+        env:
+          BRANCH: ${{ github.event.inputs.branch }}
+          WORKSPACE: ${{ github.workspace }}
+        run: |
+          cd /tmp
+          git clone --branch "$BRANCH" --depth 1 https://github.com/percy/cli
+          cd cli
+          PERCY_PACKAGES=`find packages -mindepth 1 -maxdepth 1 -type d | sed -e 's/packages/@percy/g' | tr '\n' ' '`
+          yarn
+          yarn build
+          yarn global:link
+          cd "$WORKSPACE"
+          yarn link $PERCY_PACKAGES >/dev/null 2>&1 || true
+          echo "$(yarn global bin)" >> "$GITHUB_PATH"
+          export PATH="$(yarn global bin):$PATH"
+          percy --version
       # Run each spec via the SimpleCov runner so per-process coverage is
       # recorded and merged, then collate the merged result and enforce the gate.
       - run: for file in specs/*.rb; do echo "$file"; bundle exec ruby specs/support/run_spec.rb "$file"; done


### PR DESCRIPTION
Adds CLI-branch injection so this SDK can run regression against an unpublished @percy/cli branch (workflow_dispatch). Built CLI is put on PATH. Part of PER-9772.